### PR TITLE
isodatetodecimaldate() optional param to handle invalid dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ Example: `SELECT pad_date('20000-02', 'end')` returns _20000-02-29_ since the ye
 
 Example: `SELECT pad_date('-15232', 'start')` returns _-15232-01-01_ representing the first day of that year.
 
-#### `(float) isodatetodecimaldate(datestring)`
+#### `(float) isodatetodecimaldate(datestring, trytofixinvalid)`
 
 Parse an ISO-shaped date string, and return the date in decimal representation.
+
+The optional parameter `trytofixinvalid` defines the handling for invalid dates such as _1917-28-31_ or _2020-13-31_
+* `NULL` (default) = an invalid date will raise an exception
+* `FALSE` = an invalid date will return NULL
+* `TRUE` = try hard to return a number; return the 1st of the month if the month is valid, or the year if even the month is invalid
 
 Example: `SELECT isodatetodecimaldate(2000-01-01)` returns _2000.001366_
 
@@ -32,6 +37,14 @@ Example: `SELECT isodatetodecimaldate(2000-12-31)` returns _2000.998634_
 Example: `SELECT isodatetodecimaldate(-2000-01-01)` returns _-2000.998634_ Note that January for CE years is more negative than December, being further from the 0 origin.
 
 Example: `SELECT isodatetodecimaldate(-2000-12-31)` returns _-2000.001366_ Note that December for CE years is less negative than December, being closer to the 0 origin.
+
+Example: `SELECT isodatetodecimaldate('1917-04-31')` results in an exception
+
+Example: `SELECT isodatetodecimaldate('1917-04-31', FALSE)` returns _NULL_
+
+Example: `SELECT isodatetodecimaldate('1917-04-31', TRUE)` returns _1917.247945_ for April 1
+
+Example: `SELECT isodatetodecimaldate('1917-13-32', TRUE)` returns _1917_ which is the year with 0 decimal portion
 
 #### `(varchar) decimaldatetoisodate(datestring)`
 

--- a/tests.sql
+++ b/tests.sql
@@ -3,17 +3,6 @@
 \set VERBOSITY terse
 BEGIN;
 
-DO $$ BEGIN RAISE INFO 'Testing: isvalidmonth()';END;$$;
-DO $$ BEGIN assert (   isvalidmonth(1)   );END;$$;
-DO $$ BEGIN assert (   isvalidmonth(7)   );END;$$;
-DO $$ BEGIN assert (   not isvalidmonth(19)   );END;$$;
-DO $$ BEGIN assert (   not isvalidmonth(-2)   );END;$$;
-DO $$ BEGIN assert (   not isvalidmonth('-2')   );END;$$;
-DO $$ BEGIN assert (   not isvalidmonth(0)   );END;$$;
-DO $$ BEGIN assert (   isvalidmonth('12')   );END;$$;
-DO $$ BEGIN assert (   isvalidmonth('1')   );END;$$;
-DO $$ BEGIN assert (   isvalidmonth('3')   );END;$$;
-
 DO $$ BEGIN RAISE INFO 'Testing: isleapyear()';END;$$;
 DO $$ BEGIN assert (   SELECT not isleapyear('1900')   );END;$$;
 DO $$ BEGIN assert (   SELECT not isleapyear(1900)   );END;$$;
@@ -52,6 +41,17 @@ DO $$ BEGIN assert (   howmanydaysinmonth('-29700', '2') = 28   );END;$$;
 DO $$ BEGIN assert (   howmanydaysinmonth(29700, 2) = 28   );END;$$;
 DO $$ BEGIN assert (   howmanydaysinmonth('-29700', 2) = 28   );END;$$;
 DO $$ BEGIN assert (   howmanydaysinmonth(29700, '2') = 28   );END;$$;
+
+DO $$ BEGIN RAISE INFO 'Testing: isvalidmonth()';END;$$;
+DO $$ BEGIN assert (   isvalidmonth(1)   );END;$$;
+DO $$ BEGIN assert (   isvalidmonth(7)   );END;$$;
+DO $$ BEGIN assert (   not isvalidmonth(19)   );END;$$;
+DO $$ BEGIN assert (   not isvalidmonth(-2)   );END;$$;
+DO $$ BEGIN assert (   not isvalidmonth('-2')   );END;$$;
+DO $$ BEGIN assert (   not isvalidmonth(0)   );END;$$;
+DO $$ BEGIN assert (   isvalidmonth('12')   );END;$$;
+DO $$ BEGIN assert (   isvalidmonth('1')   );END;$$;
+DO $$ BEGIN assert (   isvalidmonth('3')   );END;$$;
 
 DO $$ BEGIN RAISE INFO 'Testing: isvalidmonthday()';END;$$;
 DO $$ BEGIN assert (   SELECT isvalidmonthday(2000, 2, 29)   );END;$$;
@@ -135,6 +135,16 @@ DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-2000-01-01') = -2000.998634
 DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-2000-12-31') = -2000.001366   );END;$$;
 DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-1000000-01-01') = -1000000.998634   );END;$$;
 DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-1000000-12-31') = -1000000.001366   );END;$$;
+
+DO $$ BEGIN RAISE INFO 'Testing: isodatetodecimaldate() with invalid input';END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('1917-04-31', FALSE) IS NULL   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('1917-04-31', TRUE) = 1917.247945   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('1917-13-32', TRUE) = 1917   );END;$$;
+DO $$ BEGIN  -- this should raise an exception
+    SELECT isodatetodecimaldate('1917-04-31');
+	EXCEPTION WHEN data_exception THEN RETURN;
+    assert(false);
+END; $$ LANGUAGE plpgsql;
 
 DO $$ BEGIN RAISE INFO 'Testing: decimaldatetoisodate()';END;$$;
 DO $$ BEGIN assert (   SELECT decimaldatetoisodate(2000.001366) = '2000-01-01'   );END;$$;


### PR DESCRIPTION
This addresses a request in https://github.com/OpenHistoricalMap/issues/issues/146 that the `isodatetodecimaldate()` function, may accept a parameter to define how to handle invalid dates.

Current behavior is retained, that invalid dates are an exception.

The new parameter, allows a choice of returning NULL or else trying to return a decimal as much as possible.