### PR TITLE
ISO 8601 for BCE, +1 offset, BCE leap, docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,15 @@ This follows ISO 8601 in that year 0000 is 1 BCE, -0001 is 2 BCE, and so on. Exp
 
 ```
 // positive dates are what you expect
-console.log( decimaldate.iso2dec('2000-01-01') )  // 2000.001366
-console.log( decimaldate.dec2iso(2000.001366) )  // 2000-01-01
+SELECT decimaldate.iso2dec('2000-01-01');  -- 2000.001366
+SELECT decimaldate.dec2iso(2000.001366);  -- 2000-01-01
 
 // off by 1: 0 = 1, -1 = -2, and so on
-console.log( decimaldate.iso2dec('-2000-01-01') )  // -1999.998634
-console.log( decimaldate.dec2iso(-2000.998634) )  // -2001-01-01
+SELECT decimaldate.iso2dec('-2000-01-01');  -- -1999.998634
+SELECT decimaldate.dec2iso(-2000.998634));  -- -2001-01-01
 
 // but it unpacks the same
-decimaldate.dec2iso(decimaldate.iso2dec('-1000-06-30'))  // -1000-06-30
+SELECT decimaldate.dec2iso(decimaldate.iso2dec('-1000-06-30'))  // -1000-06-30
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -117,13 +117,51 @@ Example: `SELECT isvalidmonthday(-1999, 2, 29)` return _false_ because February 
 Example: `SELECT isvalidmonthday(2000, 1, 34)` return _false_ because January has 31 days.
 
 
-### Year 0 and Subtracting Decimal Dates
+### Dates Less Than 0001-01-01
 
-The Gregorian calendar has no year 0. The morning after Dec 31 of 1 BCE would be Jan 1 of 1 CE, without a span of two years having passed (-1 to 0, and 0 to +1).
+This follows ISO 8601 in that year 0000 is 1 BCE, -0001 is 2 BCE, and so on. Expect negative dates to seem off by 1.
 
-This is important to keep in mind when trying to subtract one date from another, and crossing the CE/BCE boundary: **You must subtract 2 years from the mathematical difference to find the real difference.**
+```
+// positive dates are what you expect
+console.log( decimaldate.iso2dec('2000-01-01') )  // 2000.001366
+console.log( decimaldate.dec2iso(2000.001366) )  // 2000-01-01
 
-This is a known issue with calculating differences across the BCE/CE boundary, and is not novel to this expression of dates as decimal format.
+// off by 1: 0 = 1, -1 = -2, and so on
+console.log( decimaldate.iso2dec('-2000-01-01') )  // -1999.998634
+console.log( decimaldate.dec2iso(-2000.998634) )  // -2001-01-01
+
+// but it unpacks the same
+decimaldate.dec2iso(decimaldate.iso2dec('-1000-06-30'))  // -1000-06-30
+```
+
+
+### Year 0 and the Number Line
+
+The Gregorian calendar has no year 0, and the morning after Dec 31 of 1 BCE would be Jan 1 of 1 CE.
+
+On a number line from BCE to CE, the value 0 would appear at the cusp between December 31 1 BCE (0000-12-31) and January 1 1 CE (0001-01-01).
+
+Decimaldate can be thought of as an offset on that number line.
+- +0.25 would be 3 months forward into 1 CE (early April)
+- +1.5 would be a year and a half forward from 0, so early July of 2 CE
+- -0.5 would be half a year backward into 1 BCE (early October)
+- -1.5 would be a year and a half backward from 0, so early July of 2 BCE
+
+However, decimaldate shifts the origin by 1 year to make positive dates look more intuitive. While it is mathematically correct that +2022.9 is November 2023, people reading decimal dates visually just didn't like the numbers looking like that. As such, +1 is added to decimal dates.
+
+| true decimal | decimaldate | iso | comment |
+| --- | --- | --- | --- |
+| -1.998633 | -0.998633 | -0001-01-01 | first day of 2 CE, most negative (highest decimal portion) day of the year |
+| -1.001366 | -0.001366 | -0001-12-31 | the last day of 2 BCE, least negative (lowest decimal portion) day of the year |
+| -0.998633 | 0.001367 | 0000-01-01 | first day of 1 BCE, most negative (highest decimal portion) day of the year |
+| -0.5 | 0.5 | 0000-07-02 | middle of 1 BCE, 6 months before the 0 origin of Jan 1 1 CE |
+| -0.001366 | 0.998634 | 0000-12-31 | the last day of 1 BCE, least negative (lowest decimal portion) day of the year |
+| 0 | 1 | cusp | the cusp between Dec 31 1 BCE (0000-12-31) and Jan 1 1 CE (0001-01-01) |
+| +0.001369 | +1.001369 | 0001-01-01 | the first day of 1 CE, least positive day of the year |
+| +0.5 | +1.5 | 0001-07-01 | middle of 1 CE, 6 months after the 0 origin of Jan 1 1 CE |
+| +0.998631 | +1.998631 | 0001-12-31 | last day of 1 CE, most positive day of the year |
+| +1.001369 | +2.001369 | 0002-01-01 | the first day of 2 CE, least positive day of the year |
+| +1.998631 | +2.998631 | 0002-12-31 | last day of 2 CE, most positive day of the year |
 
 
 ### Our Use Case and Technical Challenges

--- a/tests.sql
+++ b/tests.sql
@@ -4,43 +4,36 @@
 BEGIN;
 
 DO $$ BEGIN RAISE INFO 'Testing: isleapyear()';END;$$;
-DO $$ BEGIN assert (   SELECT not isleapyear('1900')   );END;$$;
-DO $$ BEGIN assert (   SELECT not isleapyear(1900)   );END;$$;
-DO $$ BEGIN assert (   SELECT not isleapyear(-1900)   );END;$$;
-DO $$ BEGIN assert (   SELECT not isleapyear('-1900')   );END;$$;
-DO $$ BEGIN assert (   SELECT not isleapyear('21900')   );END;$$;
-DO $$ BEGIN assert (   SELECT not isleapyear(21900)   );END;$$;
-DO $$ BEGIN assert (   SELECT not isleapyear(-21900)   );END;$$;
-DO $$ BEGIN assert (   SELECT not isleapyear('-21900')   );END;$$;
-
+DO $$ BEGIN assert (   SELECT isleapyear(-1)   );END;$$;  -- BCE leap years: -1, -5, ...
+DO $$ BEGIN assert (   SELECT isleapyear('-1')   );END;$$;  -- BCE leap years: -1, -5, ...
+DO $$ BEGIN assert (   SELECT not isleapyear(-4)   );END;$$;  -- BCE leap years: -1, -5, ...
+DO $$ BEGIN assert (   SELECT not isleapyear('-4')   );END;$$;  -- BCE leap years: -1, -5, ...
+DO $$ BEGIN assert (   SELECT not isleapyear('1900')   );END;$$;  -- not on centuries unless also 1000s
+DO $$ BEGIN assert (   SELECT not isleapyear(1900)   );END;$$;  -- not on centuries unless also 1000s
+DO $$ BEGIN assert (   SELECT not isleapyear(-1901)   );END;$$;  -- BCE leap years: -1, -5, ... but still not on centuries unless also 1000s
+DO $$ BEGIN assert (   SELECT not isleapyear('-1901')   );END;$$;  -- BCE leap years: -1, -5, ... but still not on centuries unless also 1000s
 DO $$ BEGIN assert (   SELECT isleapyear('1684')   );END;$$;
 DO $$ BEGIN assert (   SELECT isleapyear(1684)   );END;$$;
-DO $$ BEGIN assert (   SELECT isleapyear('-1684')   );END;$$;
-DO $$ BEGIN assert (   SELECT isleapyear(-1684)   );END;$$;
-DO $$ BEGIN assert (   SELECT isleapyear('22000')   );END;$$;
-DO $$ BEGIN assert (   SELECT isleapyear(22000)   );END;$$;
-DO $$ BEGIN assert (   SELECT isleapyear(-22000)   );END;$$;
-DO $$ BEGIN assert (   SELECT isleapyear('-22000')   );END;$$;
+DO $$ BEGIN assert (   SELECT not isleapyear('-1684')   );END;$$;  -- BCE leap years: -1, -5, ... but still not on centuries unless also 1000s
+DO $$ BEGIN assert (   SELECT not isleapyear(-1684)   );END;$$;  -- BCE leap years: -1, -5, ... but still not on centuries unless also 1000s
+DO $$ BEGIN assert (   SELECT not isleapyear('-1901')   );END;$$;  -- BCE leap years: -1, -5, ... but still not on centuries unless also 1000s
+DO $$ BEGIN assert (   SELECT not isleapyear(-1901)   );END;$$;  -- BCE leap years: -1, -5, ... but still not on centuries unless also 1000s
+DO $$ BEGIN assert (   SELECT isleapyear(-2001)   );END;$$;  -- BCE leap years: -1, -5, ... but still not on centuries unless also 1000s
+DO $$ BEGIN assert (   SELECT isleapyear('-2001')   );END;$$;  -- BCE leap years: -1, -5, ... but still not on centuries unless also 1000s
 
 DO $$ BEGIN RAISE INFO 'Testing: howmanydaysinyear()';END;$$;
 DO $$ BEGIN assert (   howmanydaysinyear(1684) = 366  );END;$$;
 DO $$ BEGIN assert (   howmanydaysinyear('1684') = 366   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinyear(-1684) = 366   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinyear('-1684') = 366   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinyear(19900) = 365  );END;$$;
-DO $$ BEGIN assert (   howmanydaysinyear('19900') = 365   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinyear(-19900) = 365   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinyear('-19900') = 365   );END;$$;
+DO $$ BEGIN assert (   howmanydaysinyear(-1684) = 365   );END;$$;  -- BCE leap years: -1, -5, ...
+DO $$ BEGIN assert (   howmanydaysinyear('-1684') = 365   );END;$$;  -- BCE leap years: -1, -5, ...
+DO $$ BEGIN assert (   howmanydaysinyear(-1685) = 366   );END;$$;  -- BCE leap years: -1, -5, ...
+DO $$ BEGIN assert (   howmanydaysinyear('-1685') = 366   );END;$$;  -- BCE leap years: -1, -5, ...
 
 DO $$ BEGIN RAISE INFO 'Testing: howmanydaysinmonth()';END;$$;
-DO $$ BEGIN assert (   howmanydaysinmonth('-1684', '2') = 29   );END;$$;
 DO $$ BEGIN assert (   howmanydaysinmonth(1684, 2) = 29   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinmonth('-1684', 2) = 29   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinmonth(1684, '2') = 29   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinmonth('-29700', '2') = 28   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinmonth(29700, 2) = 28   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinmonth('-29700', 2) = 28   );END;$$;
-DO $$ BEGIN assert (   howmanydaysinmonth(29700, '2') = 28   );END;$$;
+DO $$ BEGIN assert (   howmanydaysinmonth(1685, '2') = 28   );END;$$;
+DO $$ BEGIN assert (   howmanydaysinmonth('-1684', '2') = 28   );END;$$;
+DO $$ BEGIN assert (   howmanydaysinmonth('-1685', 2) = 29   );END;$$;
 
 DO $$ BEGIN RAISE INFO 'Testing: isvalidmonth()';END;$$;
 DO $$ BEGIN assert (   isvalidmonth(1)   );END;$$;
@@ -74,8 +67,8 @@ DO $$ BEGIN assert (   SELECT not isvalidmonthday(-1999, 1, 32)   );END;$$;
 DO $$ BEGIN assert (   SELECT not isvalidmonthday(-1999, 1, '-2')   );END;$$;
 DO $$ BEGIN assert (   SELECT not isvalidmonthday(2999, 1, 32)   );END;$$;
 DO $$ BEGIN assert (   SELECT not isvalidmonthday(2999, 1, '-2')   );END;$$;
-DO $$ BEGIN assert (   SELECT not SELECT isvalidmonthday(2999, 13, 1)   );END;$$;
-DO $$ BEGIN assert (   SELECT not SELECT isvalidmonthday(2999, -1, 1)   );END;$$;
+DO $$ BEGIN assert (   SELECT not isvalidmonthday(2999, 13, 1)   );END;$$;
+DO $$ BEGIN assert (   SELECT not isvalidmonthday(2999, -1, 1)   );END;$$;
 
 DO $$ BEGIN RAISE INFO 'Testing: splitdatestring()';END;$$;
 DO $$ BEGIN assert (   SELECT splitdatestring('2000-12-31') = ARRAY[2000,12,31]   );END;$$;
@@ -87,11 +80,10 @@ DO $$ BEGIN assert (   SELECT yday(1900, 12, 31) = 365   );END;$$;
 DO $$ BEGIN assert (   SELECT yday(2000, 12, 31) = 366   );END;$$;
 DO $$ BEGIN assert (   SELECT yday('-1700', 1, 1) = 1   );END;$$;
 DO $$ BEGIN assert (   SELECT yday('-1700', 12, '31') = 365   );END;$$;
-DO $$ BEGIN assert (   SELECT yday('-2000', '12', 31) = 366   );END;$$;
-DO $$ BEGIN assert (   SELECT yday(-1600, '12', '31') = 366   );END;$$;
-DO $$ BEGIN assert (   SELECT yday('-1599', '12', '31') = 365   );END;$$;
-DO $$ BEGIN assert (   SELECT yday(-21599, 12, '31') = 365   );END;$$;
-DO $$ BEGIN assert (   SELECT yday(21599, '12', 31) = 365   );END;$$;
+DO $$ BEGIN assert (   SELECT yday('-2001', '12', 31) = 366   );END;$$;
+DO $$ BEGIN assert (   SELECT yday('-2000', '12', 31) = 365   );END;$$;
+DO $$ BEGIN assert (   SELECT yday(-1601, '12', '31') = 366   );END;$$;
+DO $$ BEGIN assert (   SELECT yday('-1600', '12', '31') = 365   );END;$$;
 
 DO $$ BEGIN RAISE INFO 'Testing: pad_date() passthroughs';END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('', 'start') = ''   );END;$$;
@@ -100,7 +92,7 @@ DO $$ BEGIN assert (   SELECT pad_date('218-02-29', 'start') = '218-02-29'   );E
 DO $$ BEGIN assert (   SELECT pad_date('44-03-15', 'start') = '44-03-15'   );END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('-5000-07-02'::varchar, 'end') = '-5000-07-02'   );END;$$;
 
-DO $$ BEGIN RAISE INFO 'Testing: pad_date() empty string on malformed, expect to see some malformed messages';END;$$;
+DO $$ BEGIN RAISE INFO 'Testing: pad_date() empty string on malformed, expect to see three malformed messages';END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('never') = ''   );END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('before 100 BC') = ''   );END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('unknown') = ''   );END;$$;
@@ -121,25 +113,33 @@ DO $$ BEGIN assert (   SELECT pad_date('-44-03'::varchar) = '-44-03-01'   );END;
 DO $$ BEGIN assert (   SELECT pad_date('+2000-07'::varchar) = '2000-07-01'   );END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('-2000-07'::varchar) = '-2000-07-01'   );END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('+2000-02'::varchar, 'end') = '2000-02-29'   );END;$$;
-DO $$ BEGIN assert (   SELECT pad_date('-2000-02'::varchar, 'end') = '-2000-02-29'   );END;$$;
+DO $$ BEGIN assert (   SELECT pad_date('-2001-02'::varchar, 'end') = '-2001-02-29'   );END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('+19900-02'::varchar, 'end') = '19900-02-28'   );END;$$;
 DO $$ BEGIN assert (   SELECT pad_date('-19900-02'::varchar, 'end') = '-19900-02-28'   );END;$$;
 
 DO $$ BEGIN RAISE INFO 'Testing: isodatetodecimaldate()';END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('2000-01-01') = 2000.001366   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('2000-12-31') = 2000.998634   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('1999-01-01') = 1999.001370   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('+1999-12-31') = 1999.998630   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('+1999-07-01') = 1999.497260   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-2000-01-01') = -2000.998634   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-2000-12-31') = -2000.001366   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-1000000-01-01') = -1000000.998634   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-1000000-12-31') = -1000000.001366   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-0002-01-01') = -1.99863   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-0002-07-02') = -1.5   );END;$$; -- non leap year, 1823rd day is July 2
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-0002-12-31') = -1.00137   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-0001-01-01') = -0.99863   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-0001-07-02') = -0.5   );END;$$; -- non leap year, 1823rd day is July 2
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('-0001-12-31') = -0.00137   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0000-01-01') = +0.00137   );END;$$; -- 1 BCE, leap year; 183rd day is July 1 due to February being longer
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0000-07-02') = +0.50137   );END;$$; -- 1 BCE, leap year; 183rd day is July 1 due to February being longer
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0000-12-31') = +0.99863   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0001-01-01') = +1.00137   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0001-07-02') = +1.5   );END;$$; -- non leap year, 1823rd day is July 2
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0001-12-31') = +1.99863   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0002-01-01') = +2.00137   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0002-07-02') = +2.5   );END;$$; -- non leap year, 1823rd day is July 2
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('0002-12-31') = +2.99863   );END;$$;
 
-DO $$ BEGIN RAISE INFO 'Testing: isodatetodecimaldate() with invalid input';END;$$;
+DO $$ BEGIN RAISE INFO 'Testing: isodatetodecimaldate() trying to fix invalid input, expect 3 warnings';END;$$;
 DO $$ BEGIN assert (   SELECT isodatetodecimaldate('1917-04-31', FALSE) IS NULL   );END;$$;
-DO $$ BEGIN assert (   SELECT isodatetodecimaldate('1917-04-31', TRUE) = 1917.247945   );END;$$;
+DO $$ BEGIN assert (   SELECT isodatetodecimaldate('1917-04-31', TRUE) = 1917.24795   );END;$$;
 DO $$ BEGIN assert (   SELECT isodatetodecimaldate('1917-13-32', TRUE) = 1917   );END;$$;
+
+DO $$ BEGIN RAISE INFO 'Testing: isodatetodecimaldate() with exception on bad input';END;$$;
 DO $$ BEGIN  -- this should raise an exception
     SELECT isodatetodecimaldate('1917-04-31');
 	EXCEPTION WHEN data_exception THEN RETURN;
@@ -147,17 +147,18 @@ DO $$ BEGIN  -- this should raise an exception
 END; $$ LANGUAGE plpgsql;
 
 DO $$ BEGIN RAISE INFO 'Testing: decimaldatetoisodate()';END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(2000.001366) = '2000-01-01'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(1999.001370) = '1999-01-01'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(2000.998634) = '2000-12-31'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(1999.998630) = '1999-12-31'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(1999.497260) = '1999-07-01'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(1999.5) = '1999-07-02'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(2000.5) = '2000-07-02'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(-2000.998634) = '-2000-01-01'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(-2000.001366) = '-2000-12-31'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(-10191.998634) = '-10191-01-01'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(-10191.001366) = '-10191-12-31'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(-0.998633) = '-0001-01-01'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(-0.5) = '-0001-07-02'   );END;$$; -- non leap year, 1823rd day is July 2
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(-0.001366) = '-0001-12-31'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+0.001367) = '0000-01-01'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+0.5) = '0000-07-01'   );END;$$; -- 1 BCE, leap year; 183rd day is July 1 due to February being longer
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+0.998634) = '0000-12-31'   );END;$$; -- 1 BCE, leap year; 183rd day is July 1 due to February being longer
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+1.001369) = '0001-01-01'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+1.5) = '0001-07-02'   );END;$$; -- non leap year, 1823rd day is July 2
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+1.998631) = '0001-12-31'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+2.001369) = '0002-01-01'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+2.5) = '0002-07-02'   );END;$$; -- non leap year, 1823rd day is July 2
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(+2.998631) = '0002-12-31'   );END;$$;
 
 DO $$ BEGIN RAISE INFO 'Testing: isodatetodecimaldate() decimaldatetoisodate() back and forth';END;$$;
 DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('2000-12-01')) = '2000-12-01'   );END;$$;
@@ -165,11 +166,11 @@ DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('2000-12
 DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('2000-02-29')) = '2000-02-29'   );END;$$;
 DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('1999-12-01')) = '1999-12-01'   );END;$$;
 DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('1999-12-31')) = '1999-12-31'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('1999-02-29')) = '1999-02-29'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('-1999-02-29')) = '-1999-02-29'   );END;$$;
 DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('10191-06-30')) = '10191-06-30'   );END;$$;
 DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('10191-07-31')) = '10191-07-31'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('-10191-06-30')) = '-10191-06-30'   );END;$$;
-DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('-10191-07-31')) = '-10191-07-31'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('-10191-06-30')) = '-10192-06-30'   );END;$$;
+DO $$ BEGIN assert (   SELECT decimaldatetoisodate(isodatetodecimaldate('-10191-07-31')) = '-10192-07-31'   );END;$$;
 
 -- done!
 DO $$ BEGIN RAISE INFO 'All tests done.';END;$$;


### PR DESCRIPTION
- improved tests and documentation
- rewrote `decimaldatetoisodate()` and `isodatetodecimaldate()` to new specification
- ...including new +1 offset to decimaldate outputs
- fixed a bunch of `=` instead of `:=` for assignments
